### PR TITLE
Add report analysis and clinical trials tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 python -m src.server.mcp_server
 ```
 
-在启动后，可按照 JSON-RPC 2.0 的格式向服务器发送请求，调用示例工具 `query_knowledge_base` 或 `query_medical_resources`。
+在启动后，可按照 JSON-RPC 2.0 的格式向服务器发送请求，调用示例工具 `query_knowledge_base`、`query_medical_resources`、`analyze_report` 或 `query_clinical_trials`。
 
 # mcp的设计想法
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -37,3 +37,38 @@ class MedicalResourceQueryRequest(BaseModel):
         if v not in allowed_types:
             raise ValueError(f"不支持的疾病类型: {v}")
         return v
+
+
+class ReportAnalysisRequest(BaseModel):
+    """Schema for medical report analysis."""
+
+    report_type: str
+    content: str
+
+    @validator("report_type")
+    def validate_report_type(cls, v: str) -> str:
+        allowed_types = ["病理", "影像", "血液", "基因"]
+        if v not in allowed_types:
+            raise ValueError(f"不支持的报告类型: {v}")
+        return v
+
+    @validator("content")
+    def validate_content(cls, v: str) -> str:
+        if len(v.strip()) < 5:
+            raise ValueError("报告内容过短")
+        return v.strip()
+
+
+class ClinicalTrialQueryRequest(BaseModel):
+    """Schema for clinical trials lookup."""
+
+    disease_type: str
+    location: str = ""
+    patient_condition: str = ""
+
+    @validator("disease_type")
+    def validate_trial_disease(cls, v: str) -> str:
+        allowed_types = ["肺癌", "乳腺癌", "胃癌", "肝癌", "结直肠癌"]
+        if v not in allowed_types:
+            raise ValueError(f"不支持的疾病类型: {v}")
+        return v

--- a/src/tools/__init__.py
+++ b/src/tools/__init__.py
@@ -1,2 +1,6 @@
 from .knowledge_base import KnowledgeBase
 from .medical_resources import MedicalResources
+from .report_analysis import ReportAnalysis
+from .clinical_trials import ClinicalTrials
+
+__all__ = ["KnowledgeBase", "MedicalResources", "ReportAnalysis", "ClinicalTrials"]

--- a/src/tools/clinical_trials.py
+++ b/src/tools/clinical_trials.py
@@ -1,0 +1,37 @@
+"""Clinical trials query tool."""
+
+from typing import List, Dict
+
+from ..utils.cache import cached_tool
+from ..utils.errors import handle_mcp_errors
+from ..schemas import ClinicalTrialQueryRequest
+
+
+class ClinicalTrials:
+    """Simple clinical trials lookup."""
+
+    def __init__(self) -> None:
+        self.data: Dict[str, List[Dict[str, str]]] = {
+            "肺癌": [
+                {"title": "EGFR抑制剂研究", "location": "北京", "criteria": "18-65岁"},
+            ],
+            "乳腺癌": [
+                {"title": "HER2靶向临床试验", "location": "上海", "criteria": "女性，18-70岁"},
+            ],
+        }
+
+    @handle_mcp_errors
+    @cached_tool()
+    async def query(
+        self, disease_type: str, location: str = "", patient_condition: str = ""
+    ) -> List[Dict[str, str]]:
+        """Return clinical trials for the given disease type and location."""
+        req = ClinicalTrialQueryRequest(
+            disease_type=disease_type, location=location, patient_condition=patient_condition
+        )
+        results = [
+            t
+            for t in self.data.get(req.disease_type, [])
+            if (not req.location or t["location"] == req.location)
+        ]
+        return results

--- a/src/tools/report_analysis.py
+++ b/src/tools/report_analysis.py
@@ -1,0 +1,22 @@
+"""Medical report analysis tool."""
+
+from typing import Dict
+
+from ..utils.cache import cached_tool
+from ..utils.errors import handle_mcp_errors
+from ..schemas import ReportAnalysisRequest
+
+
+class ReportAnalysis:
+    """Simple medical report analysis tool."""
+
+    @handle_mcp_errors
+    @cached_tool()
+    async def analyze(self, report_type: str, content: str) -> Dict[str, str]:
+        """Return a basic analysis result for the given report."""
+        req = ReportAnalysisRequest(report_type=report_type, content=content)
+        return {
+            "report_type": req.report_type,
+            "summary": f"{req.report_type}报告分析结果",
+            "suggestion": "请咨询专业医生",
+        }

--- a/tests/test_clinical_trials.py
+++ b/tests/test_clinical_trials.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.server.mcp_server import MCPServer, Request
+
+
+@pytest.mark.asyncio
+async def test_clinical_trials_query():
+    server = MCPServer()
+    req = Request(
+        id="1",
+        method="tools/call",
+        params={"name": "query_clinical_trials", "arguments": {"disease_type": "肺癌"}},
+    )
+    resp = await server.handle_request(req)
+    assert resp["result"]

--- a/tests/test_report_analysis.py
+++ b/tests/test_report_analysis.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.server.mcp_server import MCPServer, Request
+
+
+@pytest.mark.asyncio
+async def test_report_analysis():
+    server = MCPServer()
+    req = Request(
+        id="1",
+        method="tools/call",
+        params={"name": "analyze_report", "arguments": {"report_type": "病理", "content": "癌细胞呈阳性"}},
+    )
+    resp = await server.handle_request(req)
+    assert resp["result"]["report_type"] == "病理"


### PR DESCRIPTION
## Summary
- add `analyze_report` and `query_clinical_trials` tools
- expose new tools through the server
- extend request schemas
- document the extra tools in README
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cae01f8208326af877f8dda83819d