### PR TITLE
Implement capabilities and tool listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ python -m src.server.mcp_server
 
 在启动后，可按照 JSON-RPC 2.0 的格式向服务器发送请求，调用示例工具 `query_knowledge_base`、`query_medical_resources`、`analyze_report`、`query_clinical_trials`、`plan_travel`、`query_insurance_policy` 或 `query_drug_info`。
 
+### 列出服务器提供的工具
+
+```json
+{"jsonrpc": "2.0", "id": "1", "method": "tools/list", "params": {}}
+```
+
+### 获取服务器能力声明
+
+```json
+{"jsonrpc": "2.0", "id": "2", "method": "server/get_capabilities", "params": {}}
+```
+
+`server/get_capabilities` 的返回值来源于 `config/capabilities.json`，若该文件不存在或解析失败，将使用内置的默认能力声明。
+
 # mcp的设计想法
 
 1. 通过mcp，让现有能力可以开放给更多开发者和开源社区应用

--- a/config/capabilities.json
+++ b/config/capabilities.json
@@ -1,0 +1,6 @@
+{
+    "tools": {"listChanged": true},
+    "resources": {"subscribe": true, "listChanged": true},
+    "prompts": {"listChanged": true},
+    "logging": {}
+}

--- a/src/server/capabilities.py
+++ b/src/server/capabilities.py
@@ -1,0 +1,24 @@
+"""Server capability declaration."""
+
+from pathlib import Path
+import json
+
+
+_DEFAULT_CAPABILITIES = {
+    "tools": {"listChanged": True},
+    "resources": {"subscribe": True, "listChanged": True},
+    "prompts": {"listChanged": True},
+    "logging": {},
+}
+
+
+def get_capabilities() -> dict:
+    """Return server capability declaration from ``config/capabilities.json``."""
+    cfg_path = Path(__file__).resolve().parents[2] / "config" / "capabilities.json"
+    if cfg_path.exists():
+        with cfg_path.open("r", encoding="utf-8") as f:
+            try:
+                return json.load(f)
+            except json.JSONDecodeError:
+                pass
+    return _DEFAULT_CAPABILITIES

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.server.mcp_server import MCPServer, Request
+
+@pytest.mark.asyncio
+async def test_get_capabilities():
+    server = MCPServer()
+    req = Request(id="1", method="server/get_capabilities", params={})
+    resp = await server.handle_request(req)
+    assert resp["result"].get("tools")

--- a/tests/test_tool_list.py
+++ b/tests/test_tool_list.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.server.mcp_server import MCPServer, Request
+
+@pytest.mark.asyncio
+async def test_tool_list():
+    server = MCPServer()
+    req = Request(id="1", method="tools/list", params={})
+    resp = await server.handle_request(req)
+    assert any(tool["name"] == "KnowledgeBase" for tool in resp["result"])


### PR DESCRIPTION
## Summary
- add `capabilities.py` with server capability declaration
- expose capabilities and tool listing in `MCPServer`
- test new `server/get_capabilities` and `tools/list` methods
- load server capabilities from JSON config file
- document new RPC methods in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cb41b3c548326a11b83c930a71c42