### PR TITLE
Implement token auth and rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ python -m src.server.mcp_server
 
 在启动后，可按照 JSON-RPC 2.0 的格式向服务器发送请求，调用示例工具 `query_knowledge_base`、`query_medical_resources`、`analyze_report`、`query_clinical_trials`、`plan_travel`、`query_insurance_policy` 或 `query_drug_info`。
 
+所有 `tools/call` 请求需要在 `params` 中提供 `token` 字段。有效 token 可通过
+环境变量 `MCP_TOKEN` 设置（默认为 `testtoken`）。服务器会限制同一 token 在
+一小时内最多 100 次请求，超过限制将返回错误码 `-32002`。
+
 ### 列出服务器提供的工具
 
 ```json

--- a/src/security/auth.py
+++ b/src/security/auth.py
@@ -1,0 +1,9 @@
+import os
+from ..utils.errors import McpError
+
+
+def verify_token(token: str) -> None:
+    """Verify access token against ``MCP_TOKEN`` environment variable."""
+    expected = os.getenv("MCP_TOKEN", "testtoken")
+    if token != expected:
+        raise McpError(-32001, "无效的Token")

--- a/src/security/rate_limiter.py
+++ b/src/security/rate_limiter.py
@@ -1,0 +1,24 @@
+import time
+from typing import Dict, Tuple
+
+from ..utils.errors import McpError
+
+
+class RateLimiter:
+    """Simple in-memory rate limiter."""
+
+    def __init__(self, max_requests: int = 100, window: int = 3600) -> None:
+        self.max_requests = max_requests
+        self.window = window
+        self._requests: Dict[str, Tuple[int, float]] = {}
+
+    def check(self, token: str) -> None:
+        now = time.time()
+        count, start = self._requests.get(token, (0, now))
+        if now - start > self.window:
+            count = 0
+            start = now
+        if count >= self.max_requests:
+            raise McpError(-32002, "请求过于频繁")
+        self._requests[token] = (count + 1, start)
+

--- a/tests/test_auth_rate.py
+++ b/tests/test_auth_rate.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.server.mcp_server import MCPServer, Request
+from src.security.rate_limiter import RateLimiter
+
+
+@pytest.mark.asyncio
+async def test_invalid_token():
+    server = MCPServer()
+    req = Request(id="1", method="tools/call", params={"name": "query_drug_info", "arguments": {"drug_name": "阿司匹林"}, "token": "bad"})
+    resp = await server.handle_request(req)
+    assert resp["error"]["code"] == -32001
+
+
+@pytest.mark.asyncio
+async def test_rate_limit():
+    server = MCPServer()
+    server.rate_limiter = RateLimiter(max_requests=1, window=3600)
+    params = {"name": "query_drug_info", "arguments": {"drug_name": "阿司匹林"}, "token": "testtoken"}
+    req = Request(id="1", method="tools/call", params=params)
+    resp1 = await server.handle_request(req)
+    assert "result" in resp1
+    req2 = Request(id="2", method="tools/call", params=params)
+    resp2 = await server.handle_request(req2)
+    assert resp2["error"]["code"] == -32002

--- a/tests/test_clinical_trials.py
+++ b/tests/test_clinical_trials.py
@@ -14,7 +14,11 @@ async def test_clinical_trials_query():
     req = Request(
         id="1",
         method="tools/call",
-        params={"name": "query_clinical_trials", "arguments": {"disease_type": "肺癌"}},
+        params={
+            "name": "query_clinical_trials",
+            "arguments": {"disease_type": "肺癌"},
+            "token": "testtoken",
+        },
     )
     resp = await server.handle_request(req)
     assert resp["result"]

--- a/tests/test_drug_info.py
+++ b/tests/test_drug_info.py
@@ -14,7 +14,11 @@ async def test_drug_info_query():
     req = Request(
         id="1",
         method="tools/call",
-        params={"name": "query_drug_info", "arguments": {"drug_name": "阿司匹林"}},
+        params={
+            "name": "query_drug_info",
+            "arguments": {"drug_name": "阿司匹林"},
+            "token": "testtoken",
+        },
     )
     resp = await server.handle_request(req)
     assert resp["result"].get("usage") == "解热镇痛、抗炎"

--- a/tests/test_insurance_policy.py
+++ b/tests/test_insurance_policy.py
@@ -14,7 +14,11 @@ async def test_insurance_policy_query():
     req = Request(
         id="1",
         method="tools/call",
-        params={"name": "query_insurance_policy", "arguments": {"region": "北京"}},
+        params={
+            "name": "query_insurance_policy",
+            "arguments": {"region": "北京"},
+            "token": "testtoken",
+        },
     )
     resp = await server.handle_request(req)
     assert resp["result"]

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -11,7 +11,15 @@ import pytest
 @pytest.mark.asyncio
 async def test_query():
     server = MCPServer()
-    req = Request(id="1", method="tools/call", params={"name": "query_knowledge_base", "arguments": {"cancer_type": "肺癌", "query": "靶向"}})
+    req = Request(
+        id="1",
+        method="tools/call",
+        params={
+            "name": "query_knowledge_base",
+            "arguments": {"cancer_type": "肺癌", "query": "靶向"},
+            "token": "testtoken",
+        },
+    )
     resp = await server.handle_request(req)
     assert resp["result"]
 

--- a/tests/test_medical_resources.py
+++ b/tests/test_medical_resources.py
@@ -15,7 +15,11 @@ async def test_medical_resources_query():
     req = Request(
         id="1",
         method="tools/call",
-        params={"name": "query_medical_resources", "arguments": {"disease_type": "肺癌", "location": "北京"}},
+        params={
+            "name": "query_medical_resources",
+            "arguments": {"disease_type": "肺癌", "location": "北京"},
+            "token": "testtoken",
+        },
     )
     resp = await server.handle_request(req)
     assert resp["result"]

--- a/tests/test_report_analysis.py
+++ b/tests/test_report_analysis.py
@@ -14,7 +14,11 @@ async def test_report_analysis():
     req = Request(
         id="1",
         method="tools/call",
-        params={"name": "analyze_report", "arguments": {"report_type": "病理", "content": "癌细胞呈阳性"}},
+        params={
+            "name": "analyze_report",
+            "arguments": {"report_type": "病理", "content": "癌细胞呈阳性"},
+            "token": "testtoken",
+        },
     )
     resp = await server.handle_request(req)
     assert resp["result"]["report_type"] == "病理"

--- a/tests/test_travel_planner.py
+++ b/tests/test_travel_planner.py
@@ -17,6 +17,7 @@ async def test_travel_plan():
         params={
             "name": "plan_travel",
             "arguments": {"origin": "北京", "destination": "上海", "date": "2024-01-01"},
+            "token": "testtoken",
         },
     )
     resp = await server.handle_request(req)


### PR DESCRIPTION
## Summary
- add token verification and rate limiter
- enforce token check in the server and update README
- update tests to include token and add coverage for auth/rate limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb7e96ae88326830a48c0052b64d1