### PR TITLE
Implement missing modules

### DIFF
--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -1,0 +1,7 @@
+"""External integrations used by the server."""
+
+from .fastgpt_client import FastGPTClient
+from .clinicaltrials_api import ClinicalTrialsAPI
+from .external_apis import ExternalAPIClient
+
+__all__ = ["FastGPTClient", "ClinicalTrialsAPI", "ExternalAPIClient"]

--- a/src/integrations/clinicaltrials_api.py
+++ b/src/integrations/clinicaltrials_api.py
@@ -1,0 +1,19 @@
+"""Simplified wrapper for a clinical trials API."""
+
+from typing import List, Dict
+
+from ..utils.errors import handle_mcp_errors
+
+
+class ClinicalTrialsAPI:
+    """Provide access to clinical trial data."""
+
+    def __init__(self) -> None:
+        pass
+
+    @handle_mcp_errors
+    async def search(self, disease: str) -> List[Dict[str, str]]:
+        """Return mock clinical trial info for the given disease."""
+        return [
+            {"title": f"{disease} trial", "location": "N/A", "criteria": ""}
+        ]

--- a/src/integrations/external_apis.py
+++ b/src/integrations/external_apis.py
@@ -1,0 +1,15 @@
+"""Generic wrapper for other external APIs."""
+
+from ..utils.errors import handle_mcp_errors
+
+
+class ExternalAPIClient:
+    """Stub client for miscellaneous external services."""
+
+    def __init__(self) -> None:
+        pass
+
+    @handle_mcp_errors
+    async def get(self, name: str) -> str:
+        """Return a placeholder response."""
+        return f"external data for {name}"

--- a/src/integrations/fastgpt_client.py
+++ b/src/integrations/fastgpt_client.py
@@ -1,0 +1,15 @@
+"""Stub client for interacting with a FastGPT service."""
+
+from ..utils.errors import handle_mcp_errors
+
+
+class FastGPTClient:
+    """Very small wrapper around a hypothetical FastGPT API."""
+
+    def __init__(self) -> None:
+        pass
+
+    @handle_mcp_errors
+    async def query(self, prompt: str) -> str:
+        """Return a mock response for the given prompt."""
+        return f"FastGPT response for: {prompt}"

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -1,0 +1,5 @@
+"""Prompt templates for various scenarios."""
+
+from .medical_prompts import MEDICAL_PROMPTS
+
+__all__ = ["MEDICAL_PROMPTS"]

--- a/src/prompts/medical_prompts.py
+++ b/src/prompts/medical_prompts.py
@@ -1,0 +1,6 @@
+"""Collection of medical related prompt templates."""
+
+MEDICAL_PROMPTS = {
+    "welcome": "您好，我是小胰宝，为您提供医学信息咨询。",
+    "farewell": "祝您早日康复，再见。",
+}

--- a/src/resources/__init__.py
+++ b/src/resources/__init__.py
@@ -1,0 +1,6 @@
+"""Built-in resource providers."""
+
+from .knowledge_db import KnowledgeDB
+from .medical_data import MedicalData
+
+__all__ = ["KnowledgeDB", "MedicalData"]

--- a/src/resources/knowledge_db.py
+++ b/src/resources/knowledge_db.py
@@ -1,0 +1,20 @@
+"""Simple in-memory knowledge database resource."""
+
+from typing import List
+
+from ..utils.errors import handle_mcp_errors
+
+
+class KnowledgeDB:
+    """Provide articles related to different cancer types."""
+
+    def __init__(self) -> None:
+        self.articles = {
+            "肺癌": ["肺癌概述", "肺癌治疗方案"],
+            "乳腺癌": ["乳腺癌检查项目", "乳腺癌治疗"],
+        }
+
+    @handle_mcp_errors
+    async def search(self, cancer_type: str) -> List[str]:
+        """Return article titles for a given cancer type."""
+        return self.articles.get(cancer_type, [])

--- a/src/resources/medical_data.py
+++ b/src/resources/medical_data.py
@@ -1,0 +1,19 @@
+"""Stub medical data resource."""
+
+from typing import Dict
+
+from ..utils.errors import handle_mcp_errors
+
+
+class MedicalData:
+    """Provide access to simplified medical datasets."""
+
+    def __init__(self) -> None:
+        self.data: Dict[str, Dict[str, str]] = {
+            "阿司匹林": {"usage": "止痛、退热", "price": "5元"},
+        }
+
+    @handle_mcp_errors
+    async def get(self, name: str) -> Dict[str, str]:
+        """Return information about the given medical item."""
+        return self.data.get(name, {})

--- a/src/server/message_handler.py
+++ b/src/server/message_handler.py
@@ -1,0 +1,33 @@
+"""JSON-RPC message handling utilities."""
+
+import json
+from typing import Optional
+
+from .mcp_server import MCPServer, Request
+from .transport import BaseTransport
+
+
+class MessageHandler:
+    """Handle incoming JSON-RPC messages using a server and transport."""
+
+    def __init__(self, server: MCPServer, transport: BaseTransport) -> None:
+        self.server = server
+        self.transport = transport
+
+    async def handle(self) -> None:
+        """Continuously process messages from the transport."""
+        while True:
+            raw = await self.transport.receive()
+            if raw is None:
+                break
+            try:
+                data = json.loads(raw)
+                request = Request(
+                    id=data.get("id", ""),
+                    method=data.get("method", ""),
+                    params=data.get("params", {}),
+                )
+                response = await self.server.handle_request(request)
+            except Exception as e:  # pragma: no cover - unexpected errors
+                response = {"error": str(e)}
+            await self.transport.send(json.dumps(response, ensure_ascii=False))

--- a/src/server/transport.py
+++ b/src/server/transport.py
@@ -1,0 +1,30 @@
+"""Asynchronous server transport implementations."""
+
+import asyncio
+from typing import Optional
+
+
+class BaseTransport:
+    """Abstract transport base class."""
+
+    async def receive(self) -> Optional[str]:
+        raise NotImplementedError
+
+    async def send(self, data: str) -> None:
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        """Clean up transport resources."""
+        return None
+
+
+class StdioTransport(BaseTransport):
+    """Simple stdio based transport used for local testing."""
+
+    async def receive(self) -> Optional[str]:
+        loop = asyncio.get_event_loop()
+        line = await loop.run_in_executor(None, input)
+        return line if line else None
+
+    async def send(self, data: str) -> None:
+        print(data)


### PR DESCRIPTION
## Summary
- add transport and message handler modules
- implement resources and prompts packages
- stub out external integration clients
- run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865de8f353c8326bf170d6053d93dc1