### PR TITLE
Add message handling, transports, and stubs for resources

### DIFF
--- a/config/api_keys.env
+++ b/config/api_keys.env
@@ -1,0 +1,2 @@
+FASTGPT_API_KEY=your_fastgpt_key
+CLINICALTRIALS_API_KEY=your_trials_key

--- a/config/mcp_config.json
+++ b/config/mcp_config.json
@@ -1,0 +1,5 @@
+{
+    "name": "xiaoqiang-MCPx",
+    "version": "0.1.0",
+    "description": "Sample MCP server configuration"
+}

--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -1,0 +1,8 @@
+# API Documentation
+
+All interactions occur via JSON-RPC 2.0 messages.
+
+## Methods
+- `tools/list` – list available tools
+- `tools/call` – invoke a tool
+- `server/get_capabilities` – return server capability declaration

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,8 @@
+# Deployment Guide
+
+1. Install Python dependencies.
+2. Set environment variable `MCP_TOKEN` for authentication.
+3. Run the server:
+   ```bash
+   python -m src.server.mcp_server
+   ```

--- a/docs/MCP_COMPLIANCE.md
+++ b/docs/MCP_COMPLIANCE.md
@@ -1,0 +1,7 @@
+# MCP Compliance
+
+This server follows the basic MCP specification.
+
+- Supports `tools/list` and `tools/call` methods
+- Provides capability declaration via `server/get_capabilities`
+- Includes token verification and rate limiting

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -1,0 +1,5 @@
+from .fastgpt_client import FastGPTClient
+from .clinicaltrials_api import ClinicalTrialsAPI
+from .external_apis import ExternalAPI
+
+__all__ = ["FastGPTClient", "ClinicalTrialsAPI", "ExternalAPI"]

--- a/src/integrations/clinicaltrials_api.py
+++ b/src/integrations/clinicaltrials_api.py
@@ -1,0 +1,9 @@
+"""Stub interface for querying clinical trials."""
+
+from typing import List, Dict
+
+
+class ClinicalTrialsAPI:
+    async def search(self, disease: str) -> List[Dict[str, str]]:
+        """Return fake clinical trial data."""
+        return [{"title": f"Trial for {disease}", "location": "N/A"}]

--- a/src/integrations/external_apis.py
+++ b/src/integrations/external_apis.py
@@ -1,0 +1,9 @@
+"""Miscellaneous external API wrappers."""
+
+from typing import Any, Dict
+
+
+class ExternalAPI:
+    async def fetch(self, endpoint: str) -> Dict[str, Any]:
+        """Return fake data for the given endpoint."""
+        return {"endpoint": endpoint, "data": "placeholder"}

--- a/src/integrations/fastgpt_client.py
+++ b/src/integrations/fastgpt_client.py
@@ -1,0 +1,9 @@
+"""Stub client for FastGPT integration."""
+
+class FastGPTClient:
+    def __init__(self, base_url: str = "http://localhost") -> None:
+        self.base_url = base_url
+
+    async def query(self, prompt: str) -> str:
+        """Return a fake response for the given prompt."""
+        return f"fastgpt response: {prompt}"

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -1,0 +1,13 @@
+from .medical_prompts import MEDICAL_SUMMARY_PROMPT
+
+PROMPTS = {
+    "medical_summary": MEDICAL_SUMMARY_PROMPT,
+}
+
+
+def get_prompt(name: str) -> str:
+    if name not in PROMPTS:
+        raise KeyError(name)
+    return PROMPTS[name]
+
+__all__ = ["get_prompt", "MEDICAL_SUMMARY_PROMPT"]

--- a/src/prompts/medical_prompts.py
+++ b/src/prompts/medical_prompts.py
@@ -1,0 +1,3 @@
+"""Prompt templates for medical scenarios."""
+
+MEDICAL_SUMMARY_PROMPT = "请根据以下病历信息给出医学摘要：{report}"

--- a/src/resources/__init__.py
+++ b/src/resources/__init__.py
@@ -1,0 +1,4 @@
+from .knowledge_db import KnowledgeDB
+from .medical_data import MedicalData
+
+__all__ = ["KnowledgeDB", "MedicalData"]

--- a/src/resources/knowledge_db.py
+++ b/src/resources/knowledge_db.py
@@ -1,0 +1,12 @@
+"""Simple knowledge database resource."""
+
+class KnowledgeDB:
+    def __init__(self) -> None:
+        self._data = {
+            "癌症": "有关癌症的基础知识。",
+            "治疗": "常见治疗手段介绍。",
+        }
+
+    def lookup(self, term: str) -> str:
+        """Return information string for a given term."""
+        return self._data.get(term, "")

--- a/src/resources/medical_data.py
+++ b/src/resources/medical_data.py
@@ -1,0 +1,14 @@
+"""Medical data resource placeholder."""
+
+from typing import Dict, Any
+
+
+class MedicalData:
+    def __init__(self) -> None:
+        self._patients: Dict[str, Dict[str, Any]] = {
+            "p1": {"name": "张三", "age": 30},
+        }
+
+    def get(self, patient_id: str) -> Dict[str, Any]:
+        """Return fake patient data."""
+        return self._patients.get(patient_id, {})

--- a/src/security/validator.py
+++ b/src/security/validator.py
@@ -1,0 +1,14 @@
+"""Data validation helpers using Pydantic."""
+
+from typing import Type, Any
+from pydantic import BaseModel, ValidationError
+
+from ..utils.errors import McpError
+
+
+def validate(data: Any, schema: Type[BaseModel]) -> BaseModel:
+    """Validate ``data`` against ``schema`` and return the parsed model."""
+    try:
+        return schema(**data)
+    except ValidationError as e:
+        raise McpError(-32602, f"参数验证失败: {e}")

--- a/src/server/message_handler.py
+++ b/src/server/message_handler.py
@@ -1,0 +1,23 @@
+"""JSON-RPC message handling utilities."""
+
+import json
+from typing import Any, Dict
+
+from .mcp_server import MCPServer, Request
+
+
+class JSONRPCMessageHandler:
+    """Convert raw JSON-RPC strings to server responses."""
+
+    def __init__(self, server: MCPServer) -> None:
+        self.server = server
+
+    async def handle(self, message: str) -> str:
+        data: Dict[str, Any] = json.loads(message)
+        request = Request(
+            id=data.get("id"),
+            method=data.get("method"),
+            params=data.get("params", {}),
+        )
+        response = await self.server.handle_request(request)
+        return json.dumps(response, ensure_ascii=False)

--- a/src/server/transport.py
+++ b/src/server/transport.py
@@ -1,0 +1,28 @@
+import asyncio
+
+class StdioServerTransport:
+    """Simple stdio-based transport for local usage."""
+
+    async def receive(self) -> str:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, input)
+
+    async def send(self, message: str) -> None:
+        print(message)
+
+
+class SseServerTransport:
+    """Minimal async SSE-like transport using an in-memory queue."""
+
+    def __init__(self, path: str = "/message", host: str = "127.0.0.1", port: int = 8080, ssl_context=None) -> None:
+        self.path = path
+        self.host = host
+        self.port = port
+        self.ssl_context = ssl_context
+        self._queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def receive(self) -> str:
+        return await self._queue.get()
+
+    async def send(self, message: str) -> None:
+        await self._queue.put(message)

--- a/src/utils/error_handler.py
+++ b/src/utils/error_handler.py
@@ -1,0 +1,17 @@
+"""Utility helpers for logging and formatting errors."""
+
+import structlog
+
+from .errors import McpError
+
+logger = structlog.get_logger()
+
+
+def log_and_format(err: Exception) -> dict:
+    """Log ``err`` and return an error dict."""
+    if isinstance(err, McpError):
+        mcp_err = err
+    else:
+        mcp_err = McpError(-32603, str(err))
+    logger.error("mcp_error", code=mcp_err.code, message=mcp_err.message)
+    return {"code": mcp_err.code, "message": mcp_err.message}

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,0 +1,8 @@
+"""Lightweight structured logger wrapper."""
+
+import structlog
+
+
+def get_logger(name: str = "mcp") -> structlog.BoundLogger:
+    """Return a bound structlog logger."""
+    return structlog.get_logger(name)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.integrations.fastgpt_client import FastGPTClient
+from src.integrations.clinicaltrials_api import ClinicalTrialsAPI
+from src.integrations.external_apis import ExternalAPI
+
+
+@pytest.mark.asyncio
+async def test_fastgpt():
+    client = FastGPTClient()
+    resp = await client.query("hello")
+    assert "hello" in resp
+
+
+@pytest.mark.asyncio
+async def test_clinical_trials():
+    api = ClinicalTrialsAPI()
+    trials = await api.search("肺癌")
+    assert trials[0]["title"].startswith("Trial")
+
+
+@pytest.mark.asyncio
+async def test_external_api():
+    api = ExternalAPI()
+    data = await api.fetch("/foo")
+    assert data["endpoint"] == "/foo"

--- a/tests/test_mcp_compliance.py
+++ b/tests/test_mcp_compliance.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import json
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.server.mcp_server import MCPServer, Request
+from src.server.capabilities import get_capabilities
+
+
+def test_config_file():
+    cfg = Path(__file__).resolve().parents[1] / "config" / "mcp_config.json"
+    assert cfg.exists()
+    with cfg.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["name"] == "xiaoqiang-MCPx"
+
+
+@pytest.mark.asyncio
+async def test_capabilities_and_tools():
+    server = MCPServer()
+    cap_resp = await server.handle_request(Request(id="1", method="server/get_capabilities", params={}))
+    assert cap_resp["jsonrpc"] == "2.0"
+    tools_resp = await server.handle_request(Request(id="2", method="tools/list", params={}))
+    assert isinstance(tools_resp["result"], list)

--- a/tests/test_new_modules.py
+++ b/tests/test_new_modules.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+import json
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.server.mcp_server import MCPServer
+from src.server.message_handler import JSONRPCMessageHandler
+from src.resources.knowledge_db import KnowledgeDB
+from src.prompts import get_prompt
+from src.integrations.fastgpt_client import FastGPTClient
+
+
+@pytest.mark.asyncio
+async def test_message_handler_tools_list():
+    server = MCPServer()
+    handler = JSONRPCMessageHandler(server)
+    msg = json.dumps({"id": "1", "method": "tools/list", "params": {}})
+    resp_text = await handler.handle(msg)
+    resp = json.loads(resp_text)
+    assert "result" in resp
+
+
+def test_resources_and_prompts():
+    db = KnowledgeDB()
+    assert db.lookup("癌症")
+    prompt = get_prompt("medical_summary")
+    assert "医学摘要" in prompt
+
+
+@pytest.mark.asyncio
+async def test_fastgpt_client():
+    client = FastGPTClient()
+    resp = await client.query("hello")
+    assert "hello" in resp

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.resources.knowledge_db import KnowledgeDB
+from src.resources.medical_data import MedicalData
+
+
+def test_knowledge_lookup():
+    db = KnowledgeDB()
+    assert db.lookup("癌症")
+
+
+def test_medical_data():
+    md = MedicalData()
+    assert md.get("p1")["name"] == "张三"


### PR DESCRIPTION
## Summary
- implement `server.transport` and `server.message_handler`
- add placeholder resources and prompts packages
- add stub integrations module
- include small tests verifying new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865de8f353c8326bf170d6053d93dc1