### PR TITLE
Improve server security checks

### DIFF
--- a/src/security/auth.py
+++ b/src/security/auth.py
@@ -4,6 +4,8 @@ from ..utils.errors import McpError
 
 def verify_token(token: str) -> None:
     """Verify access token against ``MCP_TOKEN`` environment variable."""
-    expected = os.getenv("MCP_TOKEN", "testtoken")
+    expected = os.getenv("MCP_TOKEN")
+    if expected is None:
+        raise McpError(-32004, "服务器未配置Token")
     if token != expected:
         raise McpError(-32001, "无效的Token")

--- a/src/security/rate_limiter.py
+++ b/src/security/rate_limiter.py
@@ -12,8 +12,14 @@ class RateLimiter:
         self.window = window
         self._requests: Dict[str, Tuple[int, float]] = {}
 
+    def _purge_expired(self, now: float) -> None:
+        expired = [t for t, (_, start) in self._requests.items() if now - start > self.window]
+        for t in expired:
+            del self._requests[t]
+
     def check(self, token: str) -> None:
         now = time.time()
+        self._purge_expired(now)
         count, start = self._requests.get(token, (0, now))
         if now - start > self.window:
             count = 0

--- a/src/server/message_handler.py
+++ b/src/server/message_handler.py
@@ -2,10 +2,13 @@
 
 import json
 from typing import Optional
+import structlog
 
 from .mcp_server import MCPServer, Request
 from .transport import BaseTransport
 
+
+logger = structlog.get_logger()
 
 class MessageHandler:
     """Handle incoming JSON-RPC messages using a server and transport."""
@@ -29,5 +32,6 @@ class MessageHandler:
                 )
                 response = await self.server.handle_request(request)
             except Exception as e:  # pragma: no cover - unexpected errors
-                response = {"error": str(e)}
+                logger.error("handler_error", error=str(e))
+                response = {"error": "内部服务器错误"}
             await self.transport.send(json.dumps(response, ensure_ascii=False))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+import pytest
+
+@pytest.fixture(autouse=True)
+def set_mcp_token():
+    os.environ["MCP_TOKEN"] = "testtoken"
+    yield
+

--- a/tests/test_auth_config.py
+++ b/tests/test_auth_config.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import sys
+import os
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.security.auth import verify_token
+from src.utils.errors import McpError
+
+
+def test_missing_token_env(monkeypatch):
+    monkeypatch.delenv("MCP_TOKEN", raising=False)
+    with pytest.raises(McpError) as exc:
+        verify_token("anything")
+    assert exc.value.code == -32004
+

--- a/tests/test_mcp_server_error.py
+++ b/tests/test_mcp_server_error.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+import os
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.server.mcp_server import MCPServer, Request
+
+
+@pytest.mark.asyncio
+async def test_handle_unexpected_error(monkeypatch):
+    server = MCPServer()
+
+    def boom(token: str):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr('src.server.mcp_server.verify_token', boom)
+
+    req = Request(
+        id="1",
+        method="tools/call",
+        params={"name": "query_drug_info", "arguments": {"drug_name": "阿司匹林"}, "token": "bad", "session_id": "sess"},
+    )
+    resp = await server.handle_request(req)
+    assert resp["error"]["code"] == -32603
+

--- a/tests/test_message_handler.py
+++ b/tests/test_message_handler.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import sys
+import json
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.server.message_handler import MessageHandler
+from src.server.transport import BaseTransport
+
+
+class DummyTransport(BaseTransport):
+    def __init__(self, messages):
+        self.messages = messages
+        self.sent = []
+
+    async def receive(self):
+        return self.messages.pop(0) if self.messages else None
+
+    async def send(self, data: str):
+        self.sent.append(data)
+
+
+class ErrorServer:
+    async def handle_request(self, request):
+        raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_message_handler_generic_error():
+    transport = DummyTransport(['{"id": "1", "method": "x"}'])
+    handler = MessageHandler(ErrorServer(), transport)
+    await handler.handle()
+    assert len(transport.sent) == 1
+    resp = json.loads(transport.sent[0])
+    assert resp["error"] == "内部服务器错误"
+

--- a/tests/test_rate_limiter_cleanup.py
+++ b/tests/test_rate_limiter_cleanup.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from src.security.rate_limiter import RateLimiter
+
+
+def test_rate_limiter_cleanup(monkeypatch):
+    rl = RateLimiter(max_requests=5, window=1)
+    current = [0]
+
+    def fake_time():
+        return current[0]
+
+    monkeypatch.setattr("src.security.rate_limiter.time.time", fake_time)
+
+    rl.check("a")
+    assert "a" in rl._requests
+
+    current[0] = 2
+    rl.check("b")
+    assert "a" not in rl._requests
+    assert "b" in rl._requests
+


### PR DESCRIPTION
## Summary
- require explicit MCP_TOKEN configuration
- add cleanup to RateLimiter
- don't leak server errors in MessageHandler
- handle unexpected exceptions in MCPServer
- add fixtures and tests for new behaviors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865eceabb248326a7badb12276055ee