### PR TITLE
Add documentation files

### DIFF
--- a/docs/API_DOCS.md
+++ b/docs/API_DOCS.md
@@ -1,0 +1,45 @@
+# API Documentation
+
+This document describes the JSON-RPC 2.0 methods exposed by the MCP server.
+
+## Authentication
+
+All `tools/call` requests must include a valid token via the `token` field. The expected token can be set with the `MCP_TOKEN` environment variable (defaults to `testtoken`).
+
+## Available Methods
+
+### `tools/list`
+Returns the list of available tool names.
+
+```
+{"jsonrpc": "2.0", "id": "1", "method": "tools/list", "params": {}}
+```
+
+### `server/get_capabilities`
+Retrieves the server capability declaration loaded from `config/capabilities.json`.
+
+```
+{"jsonrpc": "2.0", "id": "2", "method": "server/get_capabilities", "params": {}}
+```
+
+### `tools/call`
+Invokes a specific tool by name. Example payload for the `query_knowledge_base` tool:
+
+```
+{
+  "jsonrpc": "2.0",
+  "id": "3",
+  "method": "tools/call",
+  "params": {
+    "token": "testtoken",
+    "name": "query_knowledge_base",
+    "arguments": {
+      "cancer_type": "肺癌",
+      "query": "靶向治疗药物有哪些"
+    }
+  }
+}
+```
+
+The exact input schema for each tool is defined in `src/schemas.py`.
+

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,29 @@
+# Deployment Guide
+
+This guide explains how to run the MCP server locally or in a production environment.
+
+## Prerequisites
+
+- Python 3.9 or newer
+- Required Python packages from `requirements.txt` (install using `pip install -r requirements.txt` if provided)
+
+## Running Locally
+
+1. Install dependencies:
+   ```bash
+   pip install structlog pydantic pytest-asyncio
+   ```
+2. Start the server:
+   ```bash
+   python -m src.server.mcp_server
+   ```
+3. Send JSON-RPC requests using the examples from [API_DOCS.md](API_DOCS.md).
+
+The server expects a token supplied via the `MCP_TOKEN` environment variable; it defaults to `testtoken`.
+
+## Production Considerations
+
+- Bind the HTTP transport to `127.0.0.1` or behind a reverse proxy.
+- Use HTTPS when exposing the server over the network.
+- Configure proper logging and monitoring as described in the README.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,9 @@
+# Documentation
+
+This directory contains reference materials for the MCP server.
+
+- [MCP_COMPLIANCE.md](MCP_COMPLIANCE.md) explains how the project conforms to the Model Context Protocol.
+- [API_DOCS.md](API_DOCS.md) details the available JSON-RPC methods.
+- [DEPLOYMENT.md](DEPLOYMENT.md) describes steps for running the server locally and in production.
+
+For a broader overview of the project, see [WIKI.md](WIKI.md).


### PR DESCRIPTION
## Summary
- add API documentation with examples
- document deployment instructions
- include README for docs directory

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865f4b76e888326a34bae852498a27c